### PR TITLE
Add Map System

### DIFF
--- a/DHBW-Game/Content/Content.mgcb
+++ b/DHBW-Game/Content/Content.mgcb
@@ -13,3 +13,6 @@
 
 #---------------------------------- Content ---------------------------------#
 
+#begin Maps/TestMap.xml
+/copy:Maps/TestMap.xml;Maps/test_map.xml
+

--- a/DHBW-Game/Content/Maps/TestMap.xml
+++ b/DHBW-Game/Content/Maps/TestMap.xml
@@ -1,0 +1,17 @@
+﻿<Map>
+    <StartPosition x="300" y="200" />
+    
+    <Objects>
+        <!-- Static segments acting as walls/platforms/ground -->
+        <Object type="TestSegment" x="400" y="500" width="400" height="50" rotation="25" />
+        <Object type="TestSegment" x="900" y="600" width="800" height="50" rotation="0" />
+        <Object type="TestSegment" x="50" y="400" width="800" height="50" rotation="90" />
+        <Object type="TestSegment" x="1200" y="400" width="800" height="50" rotation="90" />
+        <Object type="TestSegment" x="200" y="400" width="500" height="50" rotation="0" />
+        <Object type="TestSegment" x="200" y="20" width="500" height="50" rotation="0" />
+        
+        <!-- Dynamic test objects -->
+        <Object type="CircleColliderTest" x="400" y="100" mass="1" elastic="true" />
+        <Object type="RectangleColliderTest" x="500" y="200" mass="1" elastic="true" />
+    </Objects>
+</Map>

--- a/DHBW-Game/Maps/Map.cs
+++ b/DHBW-Game/Maps/Map.cs
@@ -1,0 +1,155 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+using System.Xml.Schema;
+using GameLibrary.Entities;
+using GameLibrary.Graphics;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using DHBW_Game.GameObjects;
+
+namespace DHBW_Game.Maps;
+
+public class Map
+{
+    /// <summary>
+    /// Gets the background tilemap for this map.
+    /// </summary>
+    public Tilemap Background { get; private set; }
+    
+    /// <summary>
+    /// Gets the starting position for the character in this map.
+    /// </summary>
+    public Vector2 StartPosition { get; private set; }
+    
+    /// <summary>
+    /// Gets the list of game objects placed in this map.
+    /// </summary>
+    public List<GameObject> Objects { get; private set; } = new List<GameObject>();
+    
+    /// <summary>
+    /// Creates a new map based on a map XML configuration file.
+    /// </summary>
+    /// <param name="content">The content manager used to load textures and other assets.</param>
+    /// <param name="filename">The path to the XML file, relative to the content root directory.</param>
+    /// <returns>The map created by this method.</returns>
+    public static Map FromFile(ContentManager content, string filename)
+    {
+        string filePath = Path.Combine(content.RootDirectory, filename);
+    
+        using (Stream stream = TitleContainer.OpenStream(filePath))
+        {
+            XDocument doc = XDocument.Load(stream);
+            XElement root = doc.Root;
+
+            if (root == null || root.Name != "Map")
+            {
+                throw new XmlSchemaException("Missing or invalid root element! Expected <Map>.");
+            }
+
+            Map map = new Map();
+            Vector2 startPos = Vector2.Zero;
+            Tilemap background = null;
+            List<GameObject> objects = new List<GameObject>();
+
+            // Parse StartPosition
+            XElement startElem = root.Element("StartPosition");
+            if (startElem != null)
+            {
+                float x = float.TryParse(startElem.Attribute("x")?.Value, out float parsedX) ? parsedX : 0f;
+                float y = float.TryParse(startElem.Attribute("y")?.Value, out float parsedY) ? parsedY : 0f;
+                startPos = new Vector2(x, y);
+            }
+
+            // Parse Tilemap using Tilemap.FromXmlElement
+            XElement tilemapElem = root.Element("Tilemap");
+            if (tilemapElem != null)
+            {
+                background = Tilemap.FromXmlElement(content, tilemapElem);
+            }
+
+            // Parse Objects
+            XElement objectsElem = root.Element("Objects");
+            if (objectsElem != null)
+            {
+                foreach (XElement objElem in objectsElem.Elements("Object"))
+                {
+                    string type = objElem.Attribute("type")?.Value;
+                    if (string.IsNullOrEmpty(type)) continue;
+
+                    float ox = float.TryParse(objElem.Attribute("x")?.Value, out float parsedOx) ? parsedOx : 0f;
+                    float oy = float.TryParse(objElem.Attribute("y")?.Value, out float parsedOy) ? parsedOy : 0f;
+                    Vector2 pos = new Vector2(ox, oy);
+
+                    GameObject obj = null;
+                    switch (type)
+                    {
+                        case "TestCharacter":
+                            float tcMass = float.TryParse(objElem.Attribute("mass")?.Value, out float parsedTcMass) ? parsedTcMass : 1f;
+                            bool tcElastic = bool.TryParse(objElem.Attribute("elastic")?.Value, out bool parsedTcElastic) && parsedTcElastic;
+                            obj = new TestCharacter(tcMass, tcElastic);
+                            break;
+                        case "CircleColliderTest":
+                            float ccMass = float.TryParse(objElem.Attribute("mass")?.Value, out float parsedCcMass) ? parsedCcMass : 1f;
+                            bool ccElastic = bool.TryParse(objElem.Attribute("elastic")?.Value, out bool parsedCcElastic) && parsedCcElastic;
+                            obj = new CircleColliderTest(ccMass, ccElastic);
+                            break;
+                        case "RectangleColliderTest":
+                            float rcMass = float.TryParse(objElem.Attribute("mass")?.Value, out float parsedRcMass) ? parsedRcMass : 1f;
+                            bool rcElastic = bool.TryParse(objElem.Attribute("elastic")?.Value, out bool parsedRcElastic) && parsedRcElastic;
+                            obj = new RectangleColliderTest(rcMass, rcElastic);
+                            break;
+                        case "TestSegment":
+                            int tsWidth = int.TryParse(objElem.Attribute("width")?.Value, out int parsedTsWidth) ? parsedTsWidth : 0;
+                            int tsHeight = int.TryParse(objElem.Attribute("height")?.Value, out int parsedTsHeight) ? parsedTsHeight : 0;
+                            int tsRotation = int.TryParse(objElem.Attribute("rotation")?.Value, out int parsedTsRotation) ? parsedTsRotation : 0;
+                            obj = new TestSegment(tsWidth, tsHeight, tsRotation);
+                            break;
+                        default:
+                            // Unknown type;
+                            break;
+                    }
+
+                    if (obj != null)
+                    {
+                        obj.Initialize(pos);
+                        objects.Add(obj);
+                    }
+                }
+            }
+
+            map.Background = background;
+            map.StartPosition = startPos;
+            map.Objects = objects;
+
+            return map;
+        }
+    }
+    
+    /// <summary>
+    /// Updates all game objects in this map.
+    /// </summary>
+    /// <param name="gameTime">A snapshot of the timing values for the current update cycle.</param>
+    public void Update(GameTime gameTime)
+    {
+        foreach (var obj in Objects)
+        {
+            obj.Update(gameTime);
+        }
+    }
+    
+    /// <summary>
+    /// Draws the background tilemap and all game objects in this map.
+    /// </summary>
+    /// <param name="spriteBatch">The sprite batch used to draw this map.</param>
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        Background?.Draw(spriteBatch);
+        
+        foreach (var obj in Objects)
+        {
+            obj.Draw();
+        }
+    }
+}

--- a/DHBW-Game/PhysicsCollisionMovementTest/Scenes/TestScene.cs
+++ b/DHBW-Game/PhysicsCollisionMovementTest/Scenes/TestScene.cs
@@ -1,4 +1,5 @@
 using DHBW_Game.GameObjects;
+using DHBW_Game.Maps;
 using GameLibrary;
 using GameLibrary.Physics;
 using GameLibrary.Physics.Colliders;
@@ -10,10 +11,11 @@ namespace DHBW_Game.Scenes;
 
 public class TestScene : Scene
 {
-    // Game objects
+    // Player character
     private TestCharacter _character;
-    private CircleColliderTest _circleColliderTest;
-    private RectangleColliderTest _rectangleColliderTest;
+
+    // The map instance
+    private Map _map;
     
     private readonly CollisionEngine _collisionEngine;
     private readonly PhysicsEngine _physicsEngine;
@@ -38,31 +40,12 @@ public class TestScene : Scene
     
     private void InitializeNewGame()
     {
-        // Create segments which are static and act as walls/platforms/ground.
-        TestSegment testSegment1 = new TestSegment(400, 50, 25);
-        TestSegment testSegment2 = new TestSegment(800, 50, 0);
-        TestSegment testSegment3 = new TestSegment(800, 50, 90);
-        TestSegment testSegment4 = new TestSegment(800, 50, 90);
-        TestSegment testSegment5 = new TestSegment(500, 50, 0);
-        TestSegment testSegment6 = new TestSegment(500, 50, 0);
+        // Load the map from an XML configuration file using the content manager.
+        _map = Map.FromFile(Core.Content, "Maps/test_map.xml");
         
-        // Initialize the segments at their starting position.
-        testSegment1.Initialize(new Vector2(400, 500));
-        testSegment2.Initialize(new Vector2(900, 600));
-        testSegment3.Initialize(new Vector2(50, 400));
-        testSegment4.Initialize(new Vector2(1200, 400));
-        testSegment5.Initialize(new Vector2(200, 400));
-        testSegment6.Initialize(new Vector2(200, 20));
-        
-        // Create the dynamic game objects.
+        // Create the player character separately, using the start position from the map.
         _character = new TestCharacter(mass: 2f, isElastic: false);
-        _circleColliderTest = new CircleColliderTest(mass: 1f, isElastic: true);
-        _rectangleColliderTest = new RectangleColliderTest(mass: 1f, isElastic: true);
-        
-        // Initialize the dynamic game objects at their starting position.
-        _character.Initialize(startingPosition: new Vector2(300, 200));
-        _circleColliderTest.Initialize(startingPosition: new Vector2(400, 100));
-        _rectangleColliderTest.Initialize(startingPosition: new Vector2(500, 200));
+        _character.Initialize(_map.StartPosition);
     }
     
     public override void LoadContent()
@@ -71,10 +54,11 @@ public class TestScene : Scene
     
     public override void Update(GameTime gameTime)
     {
-        // Update the game objects.
+        // Update the map (which updates all placed game objects).
+        _map.Update(gameTime);
+        
+        // Update the player character.
         _character.Update(gameTime);
-        _circleColliderTest.Update(gameTime);
-        _rectangleColliderTest.Update(gameTime);
     }
     
     public override void Draw(GameTime gameTime)
@@ -85,10 +69,11 @@ public class TestScene : Scene
         // Begin the sprite batch.
         Core.SpriteBatch.Begin(samplerState: SamplerState.PointClamp);
 
-        // Draw the game objects.
+        // Draw the map (which draws the background tilemap and all placed game objects).
+        _map.Draw(Core.SpriteBatch);
+        
+        // Draw the player character.
         _character.Draw();
-        _circleColliderTest.Draw();
-        _rectangleColliderTest.Draw();
         
         // Visualize the colliders. This enables debugging the colliders without relying on sprites which don't exactly depict the colliders.
         _collisionEngine.VisualizeColliders();

--- a/GameLibrary/Rendering/Camera.cs
+++ b/GameLibrary/Rendering/Camera.cs
@@ -106,6 +106,35 @@ public class Camera
             sprite.Draw(Core.SpriteBatch, position + Offset);
         }
     }
+    
+    /// <summary>
+    /// Draws a texture region at the specified world position, adjusted by the camera's offset.
+    /// </summary>
+    /// <param name="textureRegion">The TextureRegion to draw, containing the source texture and rectangle.</param>
+    /// <param name="spriteBatch">The SpriteBatch instance to use for drawing.</param>
+    /// <param name="position">The world-space position to draw the texture region at.</param>
+    /// <param name="color">The color tint to apply to the texture region.</param>
+    /// <param name="rotation">The rotation angle in radians to apply to the texture region.</param>
+    /// <param name="origin">The origin point for rotation and scaling, relative to the texture region's top-left corner.</param>
+    /// <param name="scale">The scale factor to apply to the x- and y-axes of the texture region.</param>
+    /// <param name="effects">Sprite effects such as flipping horizontally or vertically.</param>
+    /// <param name="layerDepth">The layer depth for sorting the texture region during rendering.</param>
+    public void Draw(
+        TextureRegion textureRegion,
+        SpriteBatch spriteBatch,
+        Vector2 position, 
+        Color color, 
+        float rotation, 
+        Vector2 origin, 
+        Vector2 scale, 
+        SpriteEffects effects, 
+        float layerDepth)
+    {
+        if (textureRegion != null)
+        {
+            textureRegion.Draw(spriteBatch, position + Offset, color, rotation, origin, scale, effects, layerDepth);
+        }
+    }
 
     /// <summary>
     /// Draws a texture at the specified world position using the provided SpriteBatch, 


### PR DESCRIPTION
I added a simple Map System to allow us to separate Map design from code. This new system allows us to define Maps in XML with a Tilemap background and Game Objects and create a Map from such a file.
The Map class then contains a Tilemap object as background and all the Game Objects aside from the player character and can be used to collectively update/draw those elements.
I updated the test map to this new system using an XML file.

I also updated the Tilemap class to now also use the camera to draw, so that the background now also moves when the camera moves.

Corresponding Task in Taiga: #42