### PR TITLE
Fix bugs #90 and #92

### DIFF
--- a/DHBW-Game/Scenes/TitleScene.cs
+++ b/DHBW-Game/Scenes/TitleScene.cs
@@ -2,7 +2,6 @@ using DHBW_Game.UI;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
 using GameLibrary;
 using GameLibrary.Scenes;
 namespace DHBW_Game.Scenes;
@@ -75,7 +74,7 @@ public class TitleScene : Scene
     
         // Create title panel
         _titlePanel = new TitlePanel(_atlas, _uiSoundEffect, 
-            () => Core.ChangeScene(new TestScene()), 
+            () => Core.ChangeScene(new GameScene()),
             () => 
             {
                 _titlePanel.Hide();
@@ -123,12 +122,6 @@ public class TitleScene : Scene
     
     public override void Update(GameTime gameTime)
     {
-        // If the user presses enter, switch to the game scene.
-        if (Core.Input.Keyboard.WasKeyJustPressed(Keys.Enter))
-        {
-            Core.ChangeScene(new TestScene());
-        }
-
         GumService.Default.Update(gameTime);
         _questionSystemPanel.Activity();
     }


### PR DESCRIPTION
Fix bugs #90 and #92 in Taiga. When merging the refactored UI system, we forgot to change to the new GameScene. Thus, TestScene instead of GameScene was selected in the TitleScene. This led to the automatic level switching not working. There was also some code in the Update method of the TitleScene which was from the MonoGame tutorial and led to the focus of the buttons not working correctly.