### PR TITLE
Add save system

### DIFF
--- a/DHBW-Game/Save_System/SaveManager.cs
+++ b/DHBW-Game/Save_System/SaveManager.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+
+namespace DHBW_Game.Save_System;
+
+/// <summary>
+/// Provides methods for saving, loading, and resetting game progress.
+/// Currently stores only the current level number.
+/// </summary>
+public static class SaveManager
+{
+    // File name for storing the progress
+    private const string SaveFileName = "progress.dat";
+
+    /// <summary>
+    /// Gets the storage directory in the user's AppData folder.
+    /// </summary>
+    /// <returns>The path to the storage directory.</returns>
+    private static string GetStorageDirectory()
+    {
+        // Construct the path to the storage directory
+        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "DHBW-Game", "Saves");
+    }
+
+    /// <summary>
+    /// Saves the current level progress to a file.
+    /// </summary>
+    /// <param name="levelNumber">The level number to save.</param>
+    public static void SaveProgress(int levelNumber)
+    {
+        var filePath = Path.Combine(GetStorageDirectory(), SaveFileName);
+
+        // Ensure the directory exists
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath) ?? string.Empty);
+
+        // Write the level number to the file
+        File.WriteAllText(filePath, levelNumber.ToString());
+    }
+
+    /// <summary>
+    /// Loads the saved level progress from the file.
+    /// </summary>
+    /// <returns>The saved level number, or 0 if no save exists or parsing fails.</returns>
+    public static int LoadProgress()
+    {
+        var filePath = Path.Combine(GetStorageDirectory(), SaveFileName);
+
+        // Check if the file exists
+        if (!File.Exists(filePath))
+        {
+            return 0;
+        }
+
+        // Read the content
+        var content = File.ReadAllText(filePath);
+
+        // Try to parse the level number
+        if (int.TryParse(content, out int levelNumber))
+        {
+            return levelNumber;
+        }
+
+        // Return 0 on parsing failure
+        return 0;
+    }
+
+    /// <summary>
+    /// Resets the saved progress by deleting the save file.
+    /// </summary>
+    public static void ResetProgress()
+    {
+        var filePath = Path.Combine(GetStorageDirectory(), SaveFileName);
+
+        // Delete the file if it exists
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+    }
+}

--- a/DHBW-Game/Scenes/GameScene.cs
+++ b/DHBW-Game/Scenes/GameScene.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System.IO;
 using DHBW_Game.Question_System;
+using DHBW_Game.Save_System;
 using Microsoft.Xna.Framework.Input;
 using MonoGameGum;
 using MonoGameTutorial;
@@ -40,6 +41,9 @@ namespace DHBW_Game.Scenes
             Core.ExitOnEscape = false;
 
             _questionPool = ServiceLocator.Get<QuestionPool>();
+
+            // Load saved progress if available
+            _currentLevelNumber = SaveManager.LoadProgress();
 
             // Initialize the user interface for the game scene.
             InitializeUI();
@@ -133,6 +137,9 @@ namespace DHBW_Game.Scenes
             // Check if the current level is completed
             if (_currentLevel?.IsCompleted == true)
             {
+                // Save progress for the next level
+                SaveManager.SaveProgress(_currentLevelNumber + 1);
+
                 NextLevel();
             }
         }

--- a/DHBW-Game/Scenes/TitleScene.cs
+++ b/DHBW-Game/Scenes/TitleScene.cs
@@ -93,7 +93,8 @@ public class TitleScene : Scene
             {
                 _optionsPanel.Hide();
                 _questionSystemPanel.Show();
-            });
+            },
+            true); // Include deep settings
         _optionsPanel.AddToRoot();
 
         // Create question system panel

--- a/DHBW-Game/UI/GameSceneUI.cs
+++ b/DHBW-Game/UI/GameSceneUI.cs
@@ -69,7 +69,8 @@ public class GameSceneUI : ContainerRuntime
             () =>
             {
                 _optionsPanel.Hide();
-            });
+            },
+            false);
         _optionsPanel.AddToRoot();
     }
 


### PR DESCRIPTION
Add an automatic save system. This system saves automatically when a level is completed. The file is stored at the same location as the questions and the encrypted API key.
The options menu design is now also updated to be based on pages. This allows for better navigation and hiding deeper settings (e. g. in the pause panel).
The game progress can be reset in the deeper settings of the options menu.

Corresponding User Story in Taiga: #21