### PR TITLE
fix: Remove Collider & PhyComponent from Enemy class

### DIFF
--- a/DHBW-Game/GameObjects/Enemy.cs
+++ b/DHBW-Game/GameObjects/Enemy.cs
@@ -46,11 +46,6 @@ public class Enemy : GameObject
         //Collider = new CircleCollider(this, new Vector2(0, 0), 30, isElastic);
 
         // Use rectangle collider
-        Collider = new RectangleCollider(this, new Vector2(0, 0), 55, 140, 0, isElastic);
-
-        PhysicsComponent = new PhysicsComponent(this, mass);
-
-        ServiceLocator.Get<PhysicsEngine>().Add(PhysicsComponent);
         _animateEnemy = new AnimateGameObject();
         _cooldown = TimeSpan.FromMilliseconds(5000);
     }


### PR DESCRIPTION
This change is made to prevent the creation of multiple colliders and physics-components. It resolves a bug in which the Student does not move as expected.