### PR TITLE
Add feedback text to reset button

### DIFF
--- a/DHBW-Game/Scenes/TitleScene.cs
+++ b/DHBW-Game/Scenes/TitleScene.cs
@@ -128,6 +128,7 @@ public class TitleScene : Scene
     public override void Update(GameTime gameTime)
     {
         GumService.Default.Update(gameTime);
+        _optionsPanel.Update(gameTime);
         _questionSystemPanel.Activity();
     }
 

--- a/DHBW-Game/UI/GameSceneUI.cs
+++ b/DHBW-Game/UI/GameSceneUI.cs
@@ -219,6 +219,7 @@ public class GameSceneUI : ContainerRuntime
         // Update the GumService to handle UI updates
         GumService.Default.Update(gameTime);
         _GPAIndicatorUI.Update(gameTime);
+        _optionsPanel.Update(gameTime);
     }
 
     /// <summary>


### PR DESCRIPTION
Add a feedback text to the reset button in the options menu. This is to have a visual feedback that the game progress was reset.

Corresponding Taiga Task: #133